### PR TITLE
chore: use HTTP for open-payments-specification submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "open-payments-specifications"]
-	path = open-payments-specifications
-	url = git@github.com:interledger/open-payments-specifications.git
+    path = open-payments-specifications
+    url = https://github.com/interledger/open-payments-specifications.git


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
